### PR TITLE
Opencode skips peer dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
   "engines": {
     "opencode": ">=1.3.14"
   },
-  "peerDependencies": {
-    "@opencode-ai/plugin": ">=1.4.3",
-    "@opentui/core": "^0.4.2",
-    "@opentui/solid": "^0.4.2",
+  "dependencies": {
+    "@opentui/core": "^0.4.5",
+    "@opentui/solid": "^0.4.5",
     "solid-js": "^1.9.12"
+  },
+  "peerDependencies": {
+    "@opencode-ai/plugin": ">=1.4.3"
   },
   "files": [
     "assets/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "oc-tps",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/Tarquinen/oc-tps"
@@ -20,7 +20,7 @@
     "@opentui/solid": "^0.4.5",
     "solid-js": "^1.9.12"
   },
-  "peerDependencies": {
+  "devDependencies": {
     "@opencode-ai/plugin": ">=1.4.3"
   },
   "files": [


### PR DESCRIPTION
Fix for https://github.com/Tarquinen/oc-tps/issues/8
Opencode skips installing peer dependencies so the plugin is silently skipped.